### PR TITLE
pcre2: fixes for 10.43

### DIFF
--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -122,6 +122,7 @@ foreach h : check_headers
 endforeach
 
 check_funs = [
+  '__builtin_mul_overflow',
   'bcopy',
   'memfd_create',
   'memmove',
@@ -132,7 +133,7 @@ check_funs = [
 
 foreach f : check_funs
   if c_compiler.has_function(f)
-    cdata.set10('HAVE_@0@'.format(f.to_upper()), true)
+    cdata.set10('HAVE_@0@'.format(f.to_upper().strip('_')), true)
   endif
 endforeach
 

--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -137,6 +137,8 @@ foreach f : check_funs
 endforeach
 
 cdata.set10('SUPPORT_PCRE2_8', true)
+cdata.set10('SUPPORT_PCRE2_16', true)
+cdata.set10('SUPPORT_PCRE2_32', true)
 cdata.set10('SUPPORT_UNICODE', true)
 
 if get_option('default_library') == 'static'

--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -6,10 +6,10 @@ project(
   version: '10.43',
 )
 
-pcre2_8_lib_version = '0.11.0'
-pcre2_16_lib_version = '0.11.0'
-pcre2_32_lib_version = '0.11.0'
-pcre2_posix_lib_version = '3.0.2'
+pcre2_8_lib_version = '0.12.0'
+pcre2_16_lib_version = '0.12.0'
+pcre2_32_lib_version = '0.12.0'
+pcre2_posix_lib_version = '3.0.5'
 
 c_compiler = meson.get_compiler('c')
 

--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -141,8 +141,10 @@ cdata.set10('SUPPORT_UNICODE', true)
 
 if get_option('default_library') == 'static'
   static_defs = ['-DPCRE2_STATIC']
+  pcre2_posix_defs = []
 else
   static_defs = []
+  pcre2_posix_defs = ['-DPCRE2POSIX_SHARED']
 endif
 
 pcre2_h = configure_file(
@@ -185,7 +187,7 @@ pcre2_posix_lib = library(
   'pcre2-posix',
   'src/pcre2posix.c',
   dependencies: libpcre2_8,
-  c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=8'],
+  c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=8', pcre2_posix_defs],
   version: pcre2_posix_lib_version,
   install: true,
   gnu_symbol_visibility: 'hidden',
@@ -194,7 +196,7 @@ pcre2_posix_lib = library(
 libpcre2_posix = declare_dependency(
   link_with: pcre2_posix_lib,
   include_directories: includes,
-  compile_args: static_defs,
+  compile_args: [static_defs, pcre2_posix_defs],
 )
 
 pcre2_16_lib = library(

--- a/subprojects/packagefiles/pcre2/meson.build
+++ b/subprojects/packagefiles/pcre2/meson.build
@@ -53,6 +53,12 @@ cdata.set('MAX_NAME_SIZE', '32')
 cdata.set('MAX_NAME_COUNT', '10000')
 cdata.set('MAX_VARLOOKBEHIND', '255')
 
+if c_compiler.has_function_attribute('visibility:default')
+  cdata.set('PCRE2_EXPORT', '__attribute__ ((visibility ("default")))')
+else
+  cdata.set('PCRE2_EXPORT', '')
+endif
+
 jit_deps = []
 if not get_option('jit').disabled() and platform_is_unixlike
   jit_deps += dependency('threads')
@@ -166,6 +172,7 @@ pcre2_8_lib = library(
   c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=8'],
   version: pcre2_8_lib_version,
   install: true,
+  gnu_symbol_visibility: 'hidden',
 )
 
 libpcre2_8 = declare_dependency(
@@ -181,6 +188,7 @@ pcre2_posix_lib = library(
   c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=8'],
   version: pcre2_posix_lib_version,
   install: true,
+  gnu_symbol_visibility: 'hidden',
 )
 
 libpcre2_posix = declare_dependency(
@@ -197,6 +205,7 @@ pcre2_16_lib = library(
   c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=16'],
   version: pcre2_16_lib_version,
   install: true,
+  gnu_symbol_visibility: 'hidden',
 )
 
 libpcre2_16 = declare_dependency(
@@ -213,6 +222,7 @@ pcre2_32_lib = library(
   c_args: [general_c_args, '-DPCRE2_CODE_UNIT_WIDTH=32'],
   version: pcre2_32_lib_version,
   install: true,
+  gnu_symbol_visibility: 'hidden',
 )
 
 libpcre2_32 = declare_dependency(


### PR DESCRIPTION
@danyeaw This should fix the build failures in https://github.com/mesonbuild/wrapdb/pull/1411, and also includes a few other 10.43-related updates.